### PR TITLE
Add API to set race start times

### DIFF
--- a/backend/controllers/racedayController.js
+++ b/backend/controllers/racedayController.js
@@ -1,6 +1,9 @@
 import { BASE_URL } from "../server.js";
 import { createQrCode } from "../services/qrCodeService.js";
-import { updateFinishTimeService } from "../services/racedayService.js"
+import {
+    updateStartTimeService,
+    updateFinishTimeService
+} from "../services/racedayService.js"
 
 /**
  * Returns the SVG code for a QR code that identifies a user in an event.
@@ -28,6 +31,39 @@ export const createRacerQrCode = async (req, res) => {
 
     } catch {
         res.status(500).json({ error: "Failed to generate QR code" });
+    }
+}
+export const updateStartTime = async (req, res) => {
+    try {
+        const { event } = req.query;
+
+        const success = await updateStartTimeService(event);        
+        if (success) {
+            return res.status(200).json({ 
+                message: "Start time recorded successfully" 
+            });
+        } else {
+            return res.status(404).json({ 
+                error: "Event not found or start time already set" 
+            });
+        }
+    } catch (error) {
+        console.error("Error updating finish time:", error);
+        
+        // Return specific HTTP codes based on error message to improve tracing 
+        // TODO: Convert to a map/lookup for better scalability
+        if (error.message === "Event is required") {
+            return res.status(400).json({ error: error.message });
+        }
+        if (error.message === "Event not found") {
+            return res.status(404).json({ error: error.message });
+        }
+        if (error.message === "Start time already recorded") {
+            return res.status(409).json({ error: error.message });
+        }
+        return res.status(500).json({ 
+            error: "Failed to update start time" 
+        });
     }
 }
 /**

--- a/backend/http/raceday.http
+++ b/backend/http/raceday.http
@@ -11,13 +11,28 @@ GET http://localhost:8080/api/raceday/make-qr?event=1
 GET http://localhost:8080/api/raceday/make-qr?event=1&userr=d3eebc99-9c0b-4ef8-bb6d-6bb9bd380a44
 
 
+# UPDATE START TIME
+# =============================================================================
+### Set start time for event 
+# Expected 200 OK: Start time recorded successfully
+PATCH http://localhost:8080/api/raceday/set-start-time?event=1
+
+### TEST: Duplicate PATCH request
+# Expected 409 Conflict: Start time already recorded
+PATCH http://localhost:8080/api/raceday/set-start-time?event=1
+
+### TEST: Invalid event
+# Expected 404 Not Found: Event not found
+PATCH http://localhost:8080/api/raceday/set-start-time?event=99
+
+
 # UPDATE FINISH TIME
 # =============================================================================
 ### Set finish time for racer
 # Expected 200 OK: Finish time recorded successfully
 GET http://localhost:8080/api/raceday/set-finish-time?event=1&user=d3eebc99-9c0b-4ef8-bb6d-6bb9bd380a44
 
-### TEST: Duplicate POST request
+### TEST: Duplicate GET request
 # Expected 409 Conflict: Finish time already recorded
 GET http://localhost:8080/api/raceday/set-finish-time?event=1&user=d3eebc99-9c0b-4ef8-bb6d-6bb9bd380a44
 

--- a/backend/repositories/racedayRepository.js
+++ b/backend/repositories/racedayRepository.js
@@ -1,7 +1,78 @@
 import pool from "../server.js";
 
 /**
- * Updates the race finish time for a specific user in a given event.
+ * Returns the registration and start_time status of a specific event.
+ * @param {number} event The event_id to get status.
+ * @returns {object|null} The event status data, or null if no record exists.
+ */
+export const getEventRegistrationStatus = async (event) => {
+    try {
+        const query = `
+            SELECT 
+                event_id IS NOT NULL AS event_exists,
+                COUNT(user_id) AS registration_count,
+                COUNT(start_time) AS start_time_count
+            FROM registrations
+            WHERE
+                event_id = $1
+                AND role = 'Runner'
+            GROUP BY event_id;
+        `;
+        const result = await pool.query(query, [event]);
+        return result.rows[0];
+
+    } catch (error) {
+        console.error("getRegistration database operation failed:", error);
+        throw new Error("Database operation failed");
+    }
+};
+/**
+ * Returns the registration of a specific user for a given event.
+ * @param {number} event The event_id that the user is registered for.
+ * @param {string} user The user_id that is registered in the event.
+ * @returns {object|null} The registration data, or null if no record exists.
+ */
+export const getRegistration = async (event, user) => {
+    try {
+        const query = `
+            SELECT * FROM registrations
+            WHERE
+                event_id = $1
+                AND user_id = $2;
+        `;
+        const result = await pool.query(query, [event, user]);
+        return result.rows[0];
+
+    } catch (error) {
+        console.error("getRegistration database operation failed:", error);
+        throw new Error("Database operation failed");
+    }
+};
+/**
+ * Updates the race start_time for a specific event.
+ * @param {number} event The event_id to set start_time for.
+ * @returns {boolean} True if the operation succeeds, otherwise false.
+ */
+export const updateStartTime = async (event) => {
+    try {
+        const nowUtc = new Date().toISOString(); // returns UTC by default
+        const query = `
+            UPDATE registrations
+            SET start_time = $1
+            WHERE
+                event_id = $2
+                AND role = 'Runner'
+        `;
+        const result = await pool.query(query, [nowUtc, event]);
+        return result.rowCount > 0;
+
+    } catch (error) {
+        console.error("setStartTime database operation failed:", error);
+        throw new Error("Database operation failed");
+    }
+}
+/**
+ * Updates the race finish_time for a specific user in a given event.
  * @param {number} event The event_id that the user is registered for.
  * @param {string} user The user_id whose finish time is being updated.
  * @returns {boolean} True if the operation succeeds, otherwise false.
@@ -27,25 +98,4 @@ export const updateFinishTime = async (event, user) => {
         throw new Error("Database operation failed");
     }
 }
-/**
- * Returns the registration of a specific user for a given event.
- * @param {number} event The event_id that the user is registered for.
- * @param {string} user The user_id that is registered in the event.
- * @returns {object|null} The registration data, or null if no record exists.
- */
-export const getRegistration = async (event, user) => {
-    try {
-        const query = `
-            SELECT * FROM registrations
-            WHERE
-                event_id = $1
-                AND user_id = $2;
-        `;
-        const result = await pool.query(query, [event, user]);
-        return result.rows[0];
 
-    } catch (error) {
-        console.error("getRegistration database operation failed:", error);
-        throw new Error("Database operation failed");
-    }
-};

--- a/backend/routes/racedayRoutes.js
+++ b/backend/routes/racedayRoutes.js
@@ -1,14 +1,16 @@
 import express from "express";
 import {
     createRacerQrCode,
+    updateStartTime,
     updateFinishTime
 } from "../controllers/racedayController.js";
 
 const router = express.Router();
 
 router.get("/make-qr", createRacerQrCode)
+router.patch("/set-start-time", updateStartTime)
 
-// Uses GET instead of POST because QR codes trigger GET requests by default
+// Uses GET instead of PATCH because QR codes trigger GET requests by default
 router.get("/set-finish-time", updateFinishTime)
 
 export default router;

--- a/backend/services/racedayService.js
+++ b/backend/services/racedayService.js
@@ -1,8 +1,41 @@
 import {
-    updateFinishTime,
-    getRegistration
+    getEventRegistrationStatus,
+    getRegistration,
+    updateStartTime,
+    updateFinishTime
 } from "../repositories/racedayRepository.js";
 
+/**
+ * Validates input and event start_time before updating the start time.
+ * @param {number} event The event_id that the user is registered for.
+ * @returns {boolean} True if the operation succeeds, otherwise false.
+ */
+export const updateStartTimeService = async (event) => {
+    
+    if (!event) {
+        throw new Error("Event is required");
+    }
+    try {
+        const eventStatus = await getEventRegistrationStatus(event);
+
+        console.log(eventStatus);
+
+        // Check if the event exists
+        if (!eventStatus || !eventStatus.event_exists) {
+            throw new Error("Event not found");
+        }
+        if (eventStatus.start_time_count !== '0') {
+            throw new Error("Start time already recorded");
+        }
+        return await updateStartTime(event);
+
+    } catch (error) {
+        console.error(
+            "updateStartTimeService database operation failed: ", error
+        );
+        throw error; // return the specific error to racedayController.js
+    }
+};
 /**
  * Validates inputs against the registration before updating the finish time.
  * @param {number} event The event_id that the user is registered for.


### PR DESCRIPTION
Adds an API that, when accessed by the Starting Official, sets the race start time for all Runners registered for the event. This addresses issue #16.

## Details:
* Assumes Starting Official validation will be handled prior to this API being called. Handling validation in this API is useless as an attacker can simply pass the `user_id` of a Starting Official to bypass checks.