### PR TITLE
Add avatar database integration

### DIFF
--- a/backend/tests/testProfilePicture.http
+++ b/backend/tests/testProfilePicture.http
@@ -1,0 +1,13 @@
+### Set avatar
+PATCH http://localhost:8080/api/profile-picture/bd548303-62b7-4535-9bc1-f6a7f30aee19
+Content-Type: multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW
+
+------WebKitFormBoundary7MA4YWxkTrZu0gW
+Content-Disposition: form-data; name="profilePicture"; filename="test-image.jpg"
+Content-Type: image/jpeg
+
+< C:\Users\samlc\Documents\definitely-sam.jpg
+------WebKitFormBoundary7MA4YWxkTrZu0gW--
+
+### Get avatar
+GET http://localhost:8080/api/profile-picture/bd548303-62b7-4535-9bc1-f6a7f30aee19


### PR DESCRIPTION
This PR updates `profilePictureRepository.js` to support GET/PATCH operations against the database, and the `users` table to store the images and their metadata. This handles issues #36 and #37. 

## Details
- Added `avatar` (BYTEA) and `avatar_meta` (JSONB) fields to the `users` table
  - `avatar` stores the binary for the image itself
  - `avatar_meta` stores the metadata for the image
- Tests can be found in `/backend/tests/testProfilePicture.http` - make sure to update the file path
- This PR only covers basic error handling; consider adding more on a separate iteration